### PR TITLE
fix: avoid nested package shadowing and bump to 2.0.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,12 @@ This project is licensed under the GPL v3 License - see the [LICENSE](LICENSE) f
 
 ## Changelog
 
-### v2.0.2 (Latest)
+### v2.0.3 (Latest)
+- Fix: Switched to relative import in `__init__.py` to avoid module shadowing when a nested `mappedin_mvf_importer/` folder exists.
+- Fix: Adjusted packaging guidance to prevent nested directory structure from marketplace installs.
+- Chore: Bump version to 2.0.3 for marketplace submission.
+
+### v2.0.2
 - **🎨 Logo Update**: Updated plugin logo for better visual consistency  
 - **🔧 Qt Resources Fix**: Regenerated Qt resources to ensure new logo displays correctly in QGIS toolbar
 - **✨ Code Quality**: Applied comprehensive linting improvements with ruff formatter

--- a/__init__.py
+++ b/__init__.py
@@ -30,6 +30,6 @@ def classFactory(iface):  # pylint: disable=invalid-name
     :type iface: QgsInterface
     """
     #
-    from mappedin_mvf_importer.mappedin_mvf_importer import MappedInMVFImporter
+    from .mappedin_mvf_importer import MappedInMVFImporter
 
     return MappedInMVFImporter(iface)

--- a/metadata.txt
+++ b/metadata.txt
@@ -2,7 +2,7 @@
 name=Mappedin MVF Importer
 qgisMinimumVersion=3.0
 description=A QGIS plugin for importing Mappedin MVF v3 (Map Venue Format) packages from local files or directly from the Mappedin API
-version=2.0.2
+version=2.0.3
 author=Mappedin
 email=help@mappedin.com
 


### PR DESCRIPTION
use relative import in __init__.py to prevent import shadowing when a nested mappedin_mvf_importer/ folder exists\n- bump version to 2.0.3 in metadata.txt\n- update README changelog for 2.0.3\n\nBuild: provide flattened zip for marketplace submission